### PR TITLE
Removed Skip 1 in Container logic.

### DIFF
--- a/VisioContainer.ps1
+++ b/VisioContainer.ps1
@@ -62,7 +62,7 @@ Function New-VisioContainer {
                 $droppedContainer.Name = $Name
             } 
             $droppedContainer.ContainerProperties.SetMargin($vis.PageUnits, 0.25)
-            $containedObjects | select-object -Skip 1 | foreach-object { 
+            $containedObjects  | foreach-object { 
                 if (-not $updatemode -or ($droppedContainer.ContainerProperties.GetMemberShapes(16 + 2) -notcontains $_.ID)) {
                     $droppedcontainer.ContainerProperties.AddMember($_, 1)
                 }


### PR DESCRIPTION
Close #73 with commit that removes skip 1

The idea was that the container already has the first object (it was dropped around the first object), so we don't have to expand the container to include it.

Removing the skip fixed the problem that the first object wasn't in the container.